### PR TITLE
grab tomorrows date when formatting the endDate initial param

### DIFF
--- a/App.js
+++ b/App.js
@@ -58,7 +58,7 @@ export default function App() {
          component={Loading}
          initialParams={{
            beginDate: new Date().toISOString().slice(0, 10).replace(/[-]/g,''),
-           endDate: (parseInt(new Date().toISOString().slice(0, 10).replace(/[-]/g,'')) + 1)
+           endDate: (parseInt(new Date(new Date().getTime() + 24 * 60 * 60 * 1000).toISOString().slice(0, 10).replace(/[-]/g,'')))
            }}
          options={{ title: 'Loading Water Levels'}}
           />


### PR DESCRIPTION
-instead of adding + 1 to todays date
There was a bug if the date was the last of the month, where the tides 
predictions api from NOAA was grabbing the wrong date